### PR TITLE
Implement reservation check-in flow and dynamic schedules

### DIFF
--- a/src/main/java/com/dxjunkyard/spocomi/api/client/ReservationRestClient.java
+++ b/src/main/java/com/dxjunkyard/spocomi/api/client/ReservationRestClient.java
@@ -1,6 +1,7 @@
 package com.dxjunkyard.spocomi.api.client;
 
 import com.dxjunkyard.spocomi.domain.resource.request.ReservationRequest;
+import com.dxjunkyard.spocomi.domain.dto.ReservationDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -8,6 +9,11 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.time.LocalDate;
+import java.util.List;
 
 
 @Component
@@ -27,6 +33,78 @@ public class ReservationRestClient {
             RestTemplate restTemplate = new RestTemplate();
             ResponseEntity<String> response = restTemplate
                     .exchange(url , HttpMethod.POST, requestEntity, String.class);
+            return response.getBody();
+        } catch (RestClientException e) {
+            logger.info("RestClient error : {}", e.toString());
+            return "NG";
+        }
+    }
+
+    public String postCheckIn(String token, Long counterId, Long userId) {
+        return postCheckAction(token, counterId, userId, "/v1/api/check-in");
+    }
+
+    public String postCheckOut(String token, Long counterId, Long userId) {
+        return postCheckAction(token, counterId, userId, "/v1/api/check-out");
+    }
+
+    public List<ReservationDTO> getEquipmentReservations(String token, Long equipmentId,
+                                                         LocalDate startDate, LocalDate endDate) {
+        return getReservations(token, equipmentId, startDate, endDate, true);
+    }
+
+    public List<ReservationDTO> getFacilityReservations(String token, Long facilityId,
+                                                        LocalDate startDate, LocalDate endDate) {
+        return getReservations(token, facilityId, startDate, endDate, false);
+    }
+
+    private List<ReservationDTO> getReservations(String token, Long targetId,
+                                                 LocalDate startDate, LocalDate endDate,
+                                                 boolean isEquipment) {
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "Bearer " + token);
+            HttpEntity<?> entity = new HttpEntity<>(headers);
+
+            String urlTemplate = isEquipment
+                    ? "/v1/api/equipment/{id}/reservations"
+                    : "/v1/api/facility/{id}/reservations";
+
+            String url = UriComponentsBuilder
+                    .fromHttpUrl(backend_api_url + urlTemplate)
+                    .queryParam("startDate", startDate)
+                    .queryParam("endDate", endDate)
+                    .buildAndExpand(targetId)
+                    .toUriString();
+
+            ResponseEntity<List<ReservationDTO>> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    entity,
+                    new ParameterizedTypeReference<List<ReservationDTO>>() {
+                    }
+            );
+            return response.getBody();
+        } catch (Exception e) {
+            logger.info("RestClient error : {}", e.toString());
+            return List.of();
+        }
+    }
+
+    private String postCheckAction(String token, Long counterId, Long userId, String path) {
+        try {
+            String url = backend_api_url + path;
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.add("Authorization", "Bearer " + token);
+            HttpEntity<String> requestEntity = new HttpEntity<>(
+                    String.format("{\"counterId\":%d,\"userId\":%d}", counterId, userId),
+                    headers
+            );
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<String> response = restTemplate
+                    .exchange(url, HttpMethod.POST, requestEntity, String.class);
             return response.getBody();
         } catch (RestClientException e) {
             logger.info("RestClient error : {}", e.toString());

--- a/src/main/java/com/dxjunkyard/spocomi/controller/UIController.java
+++ b/src/main/java/com/dxjunkyard/spocomi/controller/UIController.java
@@ -2,6 +2,7 @@ package com.dxjunkyard.spocomi.controller;
 
 import com.dxjunkyard.spocomi.api.client.CommunityRestClient;
 import com.dxjunkyard.spocomi.api.client.EventRestClient;
+import com.dxjunkyard.spocomi.api.client.ReservationRestClient;
 import com.dxjunkyard.spocomi.domain.resource.*;
 import com.dxjunkyard.spocomi.domain.resource.response.*;
 import com.dxjunkyard.spocomi.service.CommunityService;
@@ -13,11 +14,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestClientException;
+import org.springframework.http.ResponseEntity;
 import org.springframework.core.io.ClassPathResource;
 
 import javax.servlet.http.Cookie;
@@ -25,7 +28,9 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @CrossOrigin
@@ -60,6 +65,9 @@ public class UIController {
 
     @Autowired
     private CommunityService communityService;
+
+    @Autowired
+    private ReservationRestClient reservationRestClient;
 
     @GetMapping("/user/line-login")
     @ResponseBody
@@ -144,6 +152,71 @@ public class UIController {
             logger.info("RestClient error : {}", e.toString());
             return "error"; // error page遷移
         }
+    }
+
+    @GetMapping("/api/equipment/{equipmentId}/reservations")
+    @ResponseBody
+    public ResponseEntity<?> getEquipmentReservations(
+            @CookieValue(value="_token", required=false) String token,
+            @PathVariable Long equipmentId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        try {
+            return ResponseEntity.ok(
+                    reservationRestClient.getEquipmentReservations(token, equipmentId, startDate, endDate)
+            );
+        } catch (Exception e) {
+            logger.info("RestClient error : {}", e.toString());
+            return ResponseEntity.internalServerError().body(List.of());
+        }
+    }
+
+    @GetMapping("/api/facility/{facilityId}/reservations")
+    @ResponseBody
+    public ResponseEntity<?> getFacilityReservations(
+            @CookieValue(value="_token", required=false) String token,
+            @PathVariable Long facilityId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        try {
+            return ResponseEntity.ok(
+                    reservationRestClient.getFacilityReservations(token, facilityId, startDate, endDate)
+            );
+        } catch (Exception e) {
+            logger.info("RestClient error : {}", e.toString());
+            return ResponseEntity.internalServerError().body(List.of());
+        }
+    }
+
+    @PostMapping("/api/check-in")
+    @ResponseBody
+    public ResponseEntity<String> postCheckIn(
+            @CookieValue(value="_token", required=false) String token,
+            @RequestBody Map<String, Long> payload) {
+        return handleCheckAction(token, payload, true);
+    }
+
+    @PostMapping("/api/check-out")
+    @ResponseBody
+    public ResponseEntity<String> postCheckOut(
+            @CookieValue(value="_token", required=false) String token,
+            @RequestBody Map<String, Long> payload) {
+        return handleCheckAction(token, payload, false);
+    }
+
+    private ResponseEntity<String> handleCheckAction(String token, Map<String, Long> payload, boolean isCheckIn) {
+        Long counterId = payload.get("counterId");
+        Long userId = payload.get("userId");
+        if (counterId == null || userId == null) {
+            return ResponseEntity.badRequest().body("counterId and userId are required");
+        }
+        String result = isCheckIn
+                ? reservationRestClient.postCheckIn(token, counterId, userId)
+                : reservationRestClient.postCheckOut(token, counterId, userId);
+        if ("NG".equalsIgnoreCase(result)) {
+            return ResponseEntity.badRequest().body(result);
+        }
+        return ResponseEntity.ok(result);
     }
 
     /**

--- a/src/main/java/com/dxjunkyard/spocomi/domain/dto/ReservationDTO.java
+++ b/src/main/java/com/dxjunkyard/spocomi/domain/dto/ReservationDTO.java
@@ -29,4 +29,16 @@ public class ReservationDTO {
 
     // イベントテキスト（"予約"など）
     private String eventText;
+
+    // 予約の状態: 0=未利用, 1=使用中, 2=返却済
+    private Integer status;
+
+    // 予約の識別子
+    private Long reservationId;
+
+    // 窓口カウンターID
+    private Long counterId;
+
+    // 予約したユーザーID
+    private Long userId;
 }

--- a/src/main/resources/static/js/reservation.js
+++ b/src/main/resources/static/js/reservation.js
@@ -510,7 +510,210 @@ function setLocationPulldown(selectedLocation) {
       radio.addEventListener('change', (e) => {
         selectedEquipmentSet = e.target.value;
         nextBtn.classList.remove('disabled');
+        fetchReservationStatusList();
       });
     });
   });
+  fetchReservationStatusList();
+}
+
+const STATUS_TEXT = {
+  0: '未利用（チェックイン待ち）',
+  1: '使用中（チェックアウト待ち）',
+  2: '返却済'
+};
+
+function handleApiErrorResponse(response) {
+  if (response.status === 400) {
+    alert('入力内容に誤りがあります。内容をご確認ください。');
+    return true;
+  }
+  if (response.status === 401) {
+    alert('認証に失敗しました。再度ログインしてください。');
+    return true;
+  }
+  return false;
+}
+
+function calculateDateRange() {
+  const startDate = selectedDateInfo.date ? new Date(selectedDateInfo.date) : new Date();
+  const endDate = new Date(startDate);
+  endDate.setDate(startDate.getDate() + 6);
+  const toDateString = (date) => date.toISOString().split('T')[0];
+  return { start: toDateString(startDate), end: toDateString(endDate) };
+}
+
+async function fetchReservationStatusList() {
+  if (!selectedFacility && !selectedEquipmentSet) {
+    return;
+  }
+
+  const statusContainer = document.getElementById('reservationStatusList');
+  if (!statusContainer) return;
+
+  const { start, end } = calculateDateRange();
+  const requests = [];
+
+  if (selectedFacility) {
+    requests.push(
+        fetch(`/v1/api/facility/${selectedFacility}/reservations?startDate=${start}&endDate=${end}`)
+            .then(r => ({ type: 'facility', response: r }))
+    );
+  }
+
+  if (selectedEquipmentSet) {
+    requests.push(
+        fetch(`/v1/api/equipment/${selectedEquipmentSet}/reservations?startDate=${start}&endDate=${end}`)
+            .then(r => ({ type: 'equipment', response: r }))
+    );
+  }
+
+  if (requests.length === 0) return;
+
+  try {
+    const results = await Promise.all(requests);
+    const reservations = [];
+
+    for (const { response } of results) {
+      if (handleApiErrorResponse(response)) {
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(`予約情報の取得に失敗しました (${response.status})`);
+      }
+      const data = await response.json();
+      reservations.push(...data);
+    }
+
+    renderReservationStatus(reservations);
+  } catch (error) {
+    console.error(error);
+    alert('予約情報の取得に失敗しました。時間をおいて再度お試しください。');
+  }
+}
+
+function renderReservationStatus(reservations) {
+  const container = document.getElementById('reservationStatusList');
+  if (!container) return;
+  container.innerHTML = '';
+
+  if (!reservations || reservations.length === 0) {
+    container.innerHTML = '<p>表示できる予約がありません。</p>';
+    return;
+  }
+
+  reservations.forEach((res) => {
+    const statusText = STATUS_TEXT[res.status] || '状態不明';
+    const wrapper = document.createElement('div');
+    wrapper.className = 'reservation-status-item';
+
+    const info = document.createElement('p');
+    const label = res.eventText || '予約';
+    info.textContent = `${label} / ${res.date || ''} ${res.startTime || ''} - ${res.endTime || ''}`;
+
+    const status = document.createElement('p');
+    status.textContent = `ステータス: ${statusText}`;
+
+    wrapper.appendChild(info);
+    wrapper.appendChild(status);
+
+    const buttonArea = document.createElement('div');
+    buttonArea.className = 'reservation-status-actions';
+
+    if (res.status === 0) {
+      const checkInBtn = document.createElement('button');
+      checkInBtn.textContent = 'チェックイン';
+      checkInBtn.className = 'btn';
+      checkInBtn.addEventListener('click', () => handleCheckAction('check-in', res));
+      buttonArea.appendChild(checkInBtn);
+    }
+
+    if (res.status === 1) {
+      const checkOutBtn = document.createElement('button');
+      checkOutBtn.textContent = '返却（チェックアウト）';
+      checkOutBtn.className = 'btn';
+      checkOutBtn.addEventListener('click', () => handleCheckAction('check-out', res));
+      buttonArea.appendChild(checkOutBtn);
+    }
+
+    wrapper.appendChild(buttonArea);
+    container.appendChild(wrapper);
+  });
+}
+
+async function handleCheckAction(action, reservation) {
+  const counterId = reservation.counterId || Number(prompt('カウンターIDを入力してください')); 
+  const userId = reservation.userId || Number(prompt('ユーザーIDを入力してください'));
+
+  if (!counterId || !userId) {
+    alert('カウンターIDとユーザーIDが必要です。');
+    return;
+  }
+
+  const endpoint = action === 'check-in' ? '/v1/api/check-in' : '/v1/api/check-out';
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ counterId, userId })
+    });
+
+    if (handleApiErrorResponse(response)) {
+      return;
+    }
+
+    if (!response.ok) {
+      throw new Error('操作に失敗しました');
+    }
+
+    alert(action === 'check-in' ? 'チェックインが完了しました。' : '返却が完了しました。');
+    fetchReservationStatusList();
+  } catch (error) {
+    console.error(error);
+    alert('操作に失敗しました。時間をおいて再度お試しください。');
+  }
+}
+
+async function fetchEquipmentSchedules(equipmentId, startDate, endDate) {
+  try {
+    const response = await fetch(`/v1/api/equipment/${equipmentId}/reservations?startDate=${startDate}&endDate=${endDate}`);
+    if (handleApiErrorResponse(response)) {
+      return { eqReservations: [], eqClosures: [] };
+    }
+    if (!response.ok) {
+      throw new Error(`備品予約情報の取得に失敗: ${response.status}`);
+    }
+    const eqReservations = await response.json();
+    eqReservations.forEach(ev => {
+      if (!ev.eventText) {
+        ev.eventText = '予約';
+      }
+    });
+    return { eqReservations, eqClosures: [] };
+  } catch (error) {
+    console.error('備品スケジュールの取得に失敗しました:', error);
+    return { eqReservations: [], eqClosures: [] };
+  }
+}
+
+async function fetchFacilitySchedules(facilityId, startDate, endDate) {
+  try {
+    const response = await fetch(`/v1/api/facility/${facilityId}/reservations?startDate=${startDate}&endDate=${endDate}`);
+    if (handleApiErrorResponse(response)) {
+      return { faReservations: [], faClosures: [] };
+    }
+    if (!response.ok) {
+      throw new Error(`施設予約情報の取得に失敗: ${response.status}`);
+    }
+    const faReservations = await response.json();
+    faReservations.forEach(ev => {
+      if (!ev.eventText) {
+        ev.eventText = '予約';
+      }
+    });
+    return { faReservations, faClosures: [] };
+  } catch (error) {
+    console.error('設備スケジュールの取得に失敗しました:', error);
+    return { faReservations: [], faClosures: [] };
+  }
 }

--- a/src/main/resources/templates/reservation_flow.html
+++ b/src/main/resources/templates/reservation_flow.html
@@ -35,6 +35,15 @@
     <a href="#" class="btn disabled" id="prevBtn">戻る</a>
     <a href="#" class="btn" id="nextBtn">次へ</a>
   </div>
+
+  <!-- 予約状況表示 -->
+  <div class="section-box" style="margin-top:24px;">
+    <h3>予約状況</h3>
+    <p>予約状態に応じてチェックイン / 返却を行えます。</p>
+    <div id="reservationStatusList" class="reservation-status-list">
+      <p>予約情報を読み込み中...</p>
+    </div>
+  </div>
 </div>
 
 <!-- ==================== カレンダーDialog ==================== -->


### PR DESCRIPTION
## Summary
- add reservation status and check-in/out support through ReservationRestClient and UIController endpoints
- surface reservation status UI with check-in/out actions and dynamic schedule fetching
- update client DTOs and override calendar fetchers to consume real reservation data

## Testing
- `./gradlew test` *(fails: wrapper main class not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694498423c348331b27a92bf87598552)